### PR TITLE
indent: fix nested dangling lines that don't use parens

### DIFF
--- a/test/testdata/indentation_tests/comments.go
+++ b/test/testdata/indentation_tests/comments.go
@@ -1,0 +1,7 @@
+package comments
+
+func _() {
+	if foo {
+		X /* why */ /* do this */
+	}
+}

--- a/test/testdata/indentation_tests/dangling_operator.go
+++ b/test/testdata/indentation_tests/dangling_operator.go
@@ -265,6 +265,20 @@ lol` +
 		2 +
 		3
 
+	foo ||
+		foo &&
+			foo(
+				123,
+			)
+
+	foo ||
+		foo &&
+			foo{
+				{
+					foo: bar,
+				},
+			}
+
 	return 123,
 		456
 }

--- a/test/testdata/indentation_tests/multiline_if.go
+++ b/test/testdata/indentation_tests/multiline_if.go
@@ -135,4 +135,18 @@ func _() {
 		return
 	}
 
+	if foo ||
+		foo &&
+			foo ==
+				foo+
+					foo*
+						foo {
+		foo
+	}
+
+	if foo() ||
+		foo() &&
+			foo() {
+		foo
+	}
 }

--- a/test/testdata/indentation_tests/switch.go
+++ b/test/testdata/indentation_tests/switch.go
@@ -66,4 +66,11 @@ func main() {
 	// also works
 	default:
 	}
+
+	switch {
+	case 1:
+	case foo,
+		foo,
+		foo:
+	}
 }


### PR DESCRIPTION
We weren't handling cases like:

1. if foo ||
2.   foo &&
3.    foo {
4.   code()
5. }

We were indenting line 4 too far because we weren't following the
dangling lines all the way up to line 1. There can be arbitrary
amounts of nested indents with no parentheses, so to find the indent
inside the "if" block you must follow all dangling lines to the
beginning of the statement.

I also fixed a couple other minor indent issues:
 - fix an edge case with multi-line case statements where we weren't
   indenting the final line with the colon
 - fix go--end-of-line to skip multiple /* */ style comments at the
   end of the line